### PR TITLE
correct the extra space in single.html

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -20,7 +20,7 @@
                 </div>
                 <div class="small-categories-container">
                     {{ range $idx, $category := .Params.categories }}
-                    {{- if ne $idx 0 }}, {{ end }}<a href="{{ " categories/" | relURL }}{{ $category | urlize }}">{{
+                    {{- if ne $idx 0 }}, {{ end }}<a href="{{ "categories/" | relURL }}{{ $category | urlize }}">{{
                         $category }}</a>
                     {{- end }}
                 </div>


### PR DESCRIPTION
the extra space will cause the website to redirect to 404 not found page whent the user click the category link.