### PR TITLE
Changed static link '/' to 'BaseURL'  in 'layouts/partials/header.html'

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <nav class="navbar is-light" role="navigation">
     <div class="container">
         <div class="navbar-brand">
-            <a href="/" title="home" class="navbar-item">
+		<a href="{{ .Site.BaseURL }}" title="home" class="navbar-item">
                 <span class="logo">
                     <h1>{{ .Site.Title }}</h1>
                 </span>


### PR DESCRIPTION
The Home page Link can be broken or might lead the user out of the website resulting in a 404 code or exposing unused path `/`. This happens if the 'BaseURL' in `config.toml` is set to a path other than `/` This change request aims to dynamically link the home page with whatever is set in the 'BaseURL' variable. 